### PR TITLE
Pbr improvements

### DIFF
--- a/mango/src/rendering/steps/ibl_step.hpp
+++ b/mango/src/rendering/steps/ibl_step.hpp
@@ -74,7 +74,7 @@ namespace mango
         glm::mat3 m_current_rotation_scale;
         //! \brief The view projection matrix to render with.
         glm::mat4 m_view_projection;
-        //! \brief The miplevel to render th cubemap with.
+        //! \brief The miplevel to render the cubemap with.
         float m_render_level;
 
         //! \brief The width of one cubemap face.

--- a/res/shader/c_equi_to_cubemap.glsl
+++ b/res/shader/c_equi_to_cubemap.glsl
@@ -33,7 +33,7 @@ void main()
 
 vec3 cube_to_world(in ivec3 cube_coord, in vec2 cubemap_size)
 {
-    vec2 tex_coord = vec2(cube_coord.xy) / cubemap_size;
+    vec2 tex_coord = vec2(cube_coord.xy + 0.5) / cubemap_size;
     tex_coord = tex_coord  * 2.0 - 1.0;
     switch(cube_coord.z)
     {

--- a/res/shader/c_irradiance_map.glsl
+++ b/res/shader/c_irradiance_map.glsl
@@ -53,8 +53,7 @@ void main()
             // Omega_s = PI / (fSampleCount * cos(theta))
             float o = (6.0 * width_sqr) / (4.0 * float(sample_count) * n_dot_l);
             float mip_level = max(0.5 * log2(o), 0.0);
-            float bias = 1.0; // bias reduces artefacts
-
+            float bias = min(mip_level / 4.0, 1.5); // bias reduces artefacts
             irradiance += textureLod(cubemap_in, to_light, mip_level + bias).rgb * n_dot_l;
         }
     }
@@ -102,8 +101,8 @@ void importance_sample_cosinus_direction(in vec2 u, in vec3 normal, out vec3 to_
 
 vec3 cube_to_world(in ivec3 cube_coord, in vec2 cubemap_size)
 {
-    vec2 tex_coord = vec2(cube_coord.xy) / cubemap_size;
-    tex_coord = tex_coord  * 2.0 - 1.0;
+    vec2 tex_coord = vec2(cube_coord.xy + 0.5) / cubemap_size;
+    tex_coord = tex_coord * 2.0 - 1.0;
     switch(cube_coord.z)
     {
         case 0: return vec3(1.0, -tex_coord.yx);

--- a/res/shader/c_prefilter_specular_map.glsl
+++ b/res/shader/c_prefilter_specular_map.glsl
@@ -50,7 +50,7 @@ void main()
 
     vec3 prefiltered = vec3(0.0);
     float weight = 0.0;
-    uint real_sample_count = uint(float(sample_count) * roughness);
+    uint real_sample_count = uint(1.0 + float(sample_count) * roughness);
 
     for(uint s = 0; s < real_sample_count; ++s)
     {
@@ -126,8 +126,8 @@ void importance_sample_ggx_direction(in vec2 u, in vec3 view, in vec3 normal, in
 
 vec3 cube_to_world(in ivec3 cube_coord, in vec2 cubemap_size)
 {
-    vec2 tex_coord = vec2(cube_coord.xy) / cubemap_size;
-    tex_coord = tex_coord  * 2.0 - 1.0;
+    vec2 tex_coord = vec2(cube_coord.xy + 0.5) / cubemap_size;
+    tex_coord = tex_coord * 2.0 - 1.0;
     switch(cube_coord.z)
     {
         case 0: return vec3(1.0, -tex_coord.yx);

--- a/res/shader/f_deferred_lighting.glsl
+++ b/res/shader/f_deferred_lighting.glsl
@@ -116,7 +116,7 @@ vec3 calculate_image_based_light(in vec3 real_albedo, in float n_dot_v, in vec3 
     vec3 prefiltered_color = textureLod(prefiltered_specular, dominant_refl, perceptual_roughness * MAX_REFLECTION_LOD).rgb;
     vec3 specular_ibl      = prefiltered_color * (f0 * dfg.x + vec3(f90) * dfg.y);
 
-    return (diffuse_ibl + specular_ibl) * occlusion_factor;
+    return diffuse_ibl * occlusion_factor + specular_ibl;
 }
 
 vec3 uncharted2_tonemap(in vec3 color)

--- a/res/shader/f_deferred_lighting.glsl
+++ b/res/shader/f_deferred_lighting.glsl
@@ -87,8 +87,6 @@ void main()
     float f90 = saturate(dot(f0, vec3(50.0 * 0.33)));
     lighting += calculate_image_based_light(real_albedo, n_dot_v, view_dir, normal, perceptual_roughness, f0, f90, occlusion_factor);
 
-    // lighting += calculateTestLight(n_dot_v, view_dir, normal, perceptual_roughness, f0, real_albedo, position, occlusion_factor);
-
     vec3 emissive = get_emissive();
     lighting += emissive;
 
@@ -113,7 +111,8 @@ vec3 calculate_image_based_light(in vec3 real_albedo, in float n_dot_v, in vec3 
 
     vec3 refl              = -normalize(reflect(view_dir, normal));
     vec3 dominant_refl     = get_specular_dominant_direction(normal, refl, perceptual_roughness);
-    vec3 prefiltered_color = textureLod(prefiltered_specular, dominant_refl, perceptual_roughness * MAX_REFLECTION_LOD).rgb;
+    float mip_index        = perceptual_roughness * MAX_REFLECTION_LOD;
+    vec3 prefiltered_color = textureLod(prefiltered_specular, dominant_refl, mip_index).rgb;
     vec3 specular_ibl      = prefiltered_color * (f0 * dfg.x + vec3(f90) * dfg.y);
 
     return diffuse_ibl * occlusion_factor + specular_ibl;


### PR DESCRIPTION
- By sampling the center of the texel, the cubemap seams are less visible.
- Now only the diffuse part is multiplied by the occlusion map, which should be the correct behaviour.
- Bias for irradiance was adapted to prevent artefacts at hdris with extremly high contrast/dynamic range.