### PR TITLE
Added energy compensation and removed diffuse preintegration.

### DIFF
--- a/res/shader/c_prefilter_specular_map.glsl
+++ b/res/shader/c_prefilter_specular_map.glsl
@@ -113,8 +113,9 @@ void importance_sample_ggx_direction(in vec2 u, in vec3 view, in vec3 normal, in
     float a_q = a_sqr * a_sqr;
 
     float phi = u1 * TWO_PI;
-    float cos_theta = sqrt((1.0 - u2) / (1.0 + (a_q - 1.0) * u2));
-    float sin_theta = sqrt(1.0 - cos_theta * cos_theta);
+    float cos_theta2 = (1.0 - u2) / (1.0 + (a_q - 1.0) * u2);
+    float cos_theta = sqrt(cos_theta2);
+    float sin_theta = sqrt(1.0 - cos_theta2);
 
     halfway = vec3(sin_theta * cos(phi), sin_theta * sin(phi), cos_theta);
 


### PR DESCRIPTION
## Bug description
The renders were not exactly correct, because energy was lost. This should be fixed now.

## Root cause
Did not take multiscattering in account.

## Solution
Added energy compensation by adapting the lookup and the handling while rendering.

## Additional
I removed the diffuse preintegration, because there was no visible difference.

## On which OS did you test your solution?
- [x] Windows 10
- [ ] Windows (older, please add)
- [ ] Ubuntu 16.04
- [ ] Linux (other distribution or version, please add)

## Which compilers where used?
- [ ] gcc
- [ ] clang
- [x] others (please specify)
- [x] MinGW64 (gcc)

## Screenshots

Original                   |  Updated
:-------------------------:|:-------------------------:
![grafik](https://user-images.githubusercontent.com/32524715/90022399-c542cc00-dcb2-11ea-9a33-652fb05da295.png)  |  ![grafik](https://user-images.githubusercontent.com/32524715/90022551-f6bb9780-dcb2-11ea-88f1-de0cd4fcda66.png)

